### PR TITLE
Basic support for cargo search

### DIFF
--- a/cratere/__init__.py
+++ b/cratere/__init__.py
@@ -160,20 +160,17 @@ async def get_crates(request: Request) -> CrateSearchModel:
 
     TODO: Generate metadata from local index instead of proxying directly to crates.io.
     """
-    body = await request.body()
     log.info(
-        "Getting crates info: %s -- %s -- %s",
-        request.path_params,
+        "Getting crates info: %s",
         request.query_params,
-        body,
     )
     async with httpx.AsyncClient() as client:
         url = f"https://crates.io{request.url.path}"
         if request.query_params:
             url += f"?{request.query_params}"
-        r = await client.request("GET", url)
-        crate_search_model = CrateSearchModel(**r.json())
-        log.info("Got response: %s", crate_search_model)
+        r = await client.get(url)
+    crate_search_model = CrateSearchModel(**r.json())
+    log.info("Got response: %s", crate_search_model)
     return crate_search_model
 
 

--- a/cratere/__init__.py
+++ b/cratere/__init__.py
@@ -9,6 +9,7 @@ from anyio.streams.buffered import BufferedByteReceiveStream
 from fastapi import FastAPI, Request
 from fastapi.responses import StreamingResponse, FileResponse
 import httpx
+from starlette.responses import JSONResponse
 
 from cratere.settings import settings
 from cratere.logger import log
@@ -150,8 +151,21 @@ async def post_index_upload_pack(request: Request):
     )
 
 
+@app.get("/api/v1/crates/{name}")
+async def get_crate(name: str, request: Request):
+    """
+    Used by cargo search.
+    """
+    log.info("Getting crate info for %s", name)
+    async with httpx.AsyncClient() as client:
+        r = await client.get(f"https://crates.io{request.url.path}")
+        content = r.json()
+        log.info("Got response: %s", content)
+    return JSONResponse(content=content)
+
+
 @app.get("/api/v1/crates/{name}/{version}/download")
-async def get_crate(name: str, version: str, request: Request):
+async def download_crate(name: str, version: str, request: Request):
     """Serve crate download."""
     _ = await request.body()
 

--- a/cratere/search.py
+++ b/cratere/search.py
@@ -1,0 +1,51 @@
+from typing import List, Any, Optional
+from pydantic import BaseModel
+
+__all__ = [
+    "CrateLinksModel",
+    "CrateShowModel",
+    "CrateSearchMetadataModel",
+    "CrateSearchModel",
+]
+
+
+class CrateLinksModel(BaseModel):
+    owner_team: str
+    owner_user: str
+    owners: str
+    reverse_dependencies: str
+    version_downloads: str
+    versions: str
+
+
+class CrateShowModel(BaseModel):
+    badges: List
+    categories: Any
+    created_at: str
+    description: str
+    documentation: Optional[str]
+    downloads: int
+    exact_match: bool
+    homepage: Optional[str]
+    id: str
+    keywords: Any
+    links: CrateLinksModel
+    max_stable_version: Optional[str]
+    max_version: str
+    name: str
+    newest_version: str
+    recent_downloads: int
+    repository: Optional[str]
+    updated_at: str
+    versions: Any
+
+
+class CrateSearchMetadataModel(BaseModel):
+    next_page: str
+    prev_page: Any
+    total: int
+
+
+class CrateSearchModel(BaseModel):
+    crates: List[CrateShowModel]
+    meta: CrateSearchMetadataModel

--- a/cratere/search.py
+++ b/cratere/search.py
@@ -47,5 +47,10 @@ class CrateSearchMetadataModel(BaseModel):
 
 
 class CrateSearchModel(BaseModel):
+    """
+    API result of cargo search.
+
+    See https://doc.rust-lang.org/cargo/commands/cargo-search.html
+    """
     crates: List[CrateShowModel]
     meta: CrateSearchMetadataModel


### PR DESCRIPTION
For now it just proxies directly the query to crates.io.
In the future it should instead read the local metadata.

Generated the pydantic models using https://jsontopydantic.com/ so they aren't 100% accurate.